### PR TITLE
feature: add docs and example playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 ![CI](https://github.com/devrnt/react-use-intercom/workflows/CI/badge.svg?branch=master)
 
-An updated React [Intercom](https://www.intercom.com/) component to integrate in your application.
+A React [Intercom](https://www.intercom.com/) integration focused on developer experience.
+
+## Features
+* Hooks
+* Written in TypeScript
+* Documented, self explaining methods 
+* [Tiny size](https://bundlephobia.com/result?p=react-use-intercom@latest) without any external libraries
 
 ## Installation
 
@@ -10,7 +16,201 @@ An updated React [Intercom](https://www.intercom.com/) component to integrate in
 yarn add react-use-intercom
 ```
 
-## Usage
+## Quickstart
 
 ```js
+import * as React from 'react';
+
+import { IntercomProvider, useIntercom } from 'react-use-intercom';
+
+const INTERCOM_APP_ID = 'your-intercom-app-id';
+
+const App = () => (
+  <IntercomProvider appId={INTERCOM_APP_ID}>
+    <HomePage />
+  </IntercomProvider>
+);
+
+
+// Anywhere in your app
+const HomePage = () => {
+  const { boot, shutdown, hide, show, update } = useIntercom();
+
+  return <button onClick={boot}>Boot intercom! ☎️</button>;
+};
+```
+
+## API
+* [IntercomProvider](#intercomprovider)
+* [useIntercom](#useintercom)
+
+### IntercomProvider 
+`IntercomProvider` is used to initialize the `window.Intercom` instance. It makes sure the initialization is only done once. If any listeners are passed, the `IntercomProvider` will make sure these are attached.
+
+#### Props
+| name                | type             | description                                                                             | required | default |
+|---------------------|------------------|-----------------------------------------------------------------------------------------|----------|---------|
+| appId               | string           | app ID of your Intercom instance                                                        | true     |         |
+| children            | React.ReactNode  | React children                                                                          | true     |         |
+| autoBoot            | boolean          | indicates if Intercom should be automatically booted. If `true` no need to call `boot`, the `IntercomProvider` will call it for you  | false    |   false |
+| onHide              | () => void       | triggered when the Messenger hides                                                      | false    |         |
+| onShow              | () => void       | triggered when the Messenger shows                                                      | false    |         |
+| onUnreadCountChange | (number) => void | triggered when the current number of unread messages changes                            | false    |         |
+
+#### Example
+```javascript
+const App = () => {
+  const [unreadMessagesCount, unreadMessagesCount] = React.useState(0);
+
+  const onHide = () => console.log('Intercom did hide the Messenger');
+  const onShow = () => console.log('Intercom did show the Messenger');
+  const onUnreadCountChange = (amount: number) => {
+    console.log('Intercom has a new unread message');
+    unreadMessagesCount(amount);
+    console.log('New amount of unread messages: ', unreadMessagesCount);
+  };
+
+  return (
+    <IntercomProvider
+      appId={INTERCOM_APP_ID}
+      onHide={onHide}
+      onShow={onShow}
+      onUnreadCountChange={onUnreadCountChange}
+      autoBoot
+    >
+      <p>Hi there, I'm a child of the IntercomProvider</p>
+    </IntercomProvider>
+  );
+};
+```
+
+### useIntercom
+Used to retrieve all methods bundled with Intercom. These are based on the official [Intercom docs](https://developers.intercom.com/installing-intercom/docs/javascript-api-attributes-objects). Some extra methods were added to improve convenience.
+
+**Remark** - make sure `IntercomProvider` is wrapped around your component when calling `useIntercom()`
+
+#### Methods
+| name            | type                                       | description                                                                                                                         |
+|-----------------|--------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| boot            | (props?: IntercomProps) => void            | boots the Intercom instance, not needed if `autoBoot` in `IntercomProvider` is `true`                                               |
+| shutdown        | () => void                                 | shuts down the Intercom instance                                                                                                     |
+| hardShutdown    | () => void                                 | same functionality as `shutdown`, but makes sure the Intercom cookies, `window.Intercom` and `window.intercomSettings` are removed. |
+| update          | (props?: IntercomProps) => void            | updates the Intercom instance with the supplied props. To initiate a 'ping', call `update` without props                            |
+| hide            | () => void                                 | hides the Messenger, will call `onHide` if supplied to `IntercomProvider`                                                           |
+| show            | () => void                                 | shows the Messenger, will call `onShow` if supplied to `IntercomProvider`                                                           |
+| showMessages    | () => void                                 | shows the Messenger with the message list                                                                                           |
+| showNewMessages | (content?: string) => void                 | shows the Messenger as if a new conversation was just created. If `content` is passed, it will fill in the message composer         |
+| getVisitorId    | () => string                               | gets the visitor id                                                                                                                 |
+| startTour       | (tourId: number) => void                   | starts a tour based on the `tourId`                                                                                                 |
+| trackEvent      | (event: string, metaData?: object) => void | submits an `event` with optional `metaData`      
+
+#### Example
+```javascript
+import * as React from 'react';
+
+import { IntercomProvider, useIntercom } from '../../../dist';
+
+const INTERCOM_APP_ID = 'your-intercom-app-id';
+
+const App = () => (
+  <IntercomProvider appId={INTERCOM_APP_ID}>
+    <HomePage />
+  </IntercomProvider>
+);
+
+const HomePage = () => {
+  const {
+    boot,
+    shutdown,
+    hardShutdown,
+    update,
+    hide,
+    show,
+    showMessages,
+    showNewMessages,
+    getVisitorId,
+    startTour,
+    trackEvent,
+  } = useIntercom();
+
+  const bootWithProps = () => boot({ name: 'Russo' });
+  const updateWithProps = () => update({ name: 'Ossur' });
+  const handleNewMessages = () => showNewMessages();
+  const handleNewMessagesWithContent = () => showNewMessages('content');
+  const handleGetVisitorId = () => console.log(getVisitorId());
+  const handleStartTour = () => startTour(123);
+  const handleTrackEvent = () => trackEvent('invited-friend');
+  const handleTrackEventWithMetaData = () =>
+    trackEvent('invited-frind', {
+      name: 'Russo',
+    });
+
+  return (
+    <>
+      <button onClick={boot}>Boot intercom</button>
+      <button onClick={bootWithProps}>Boot with props</button>
+      <button onClick={shutdown}>Shutdown</button>
+      <button onClick={hardShutdown}>Hard shutdown</button>
+      <button onClick={update}>Update clean session</button>
+      <button onClick={updateWithProps}>Update session with props</button>
+      <button onClick={show}>Show messages</button>
+      <button onClick={hide}>Hide messages</button>
+      <button onClick={showMessages}>Show message list</button>
+      <button onClick={handleNewMessages}>Show new messages</button>
+      <button onClick={handleNewMessagesWithContent}>
+        Show new message with pre-filled content
+      </button>
+      <button onClick={handleGetVisitorId}>Get visitor id</button>
+      <button onClick={handleStartTour}>Start tour</button>
+      <button onClick={handleTrackEvent}>Track event</button>
+      <button onClick={handleTrackEventWithMetaData}>
+        Track event with metadata
+      </button>
+    </>
+  );
+};
+``` 
+
+## TypeScript
+All the possible pre-defined options to pass to the Intercom instance are typed. So where you make use of passing `IntercomProps` you get the autocompletion of the possible properties out of the bbox.
+These props are `JavaScript` 'friendly' no need to pass the props with [snake_cased](https://en.wikipedia.org/wiki/Snake_case) keys.
+
+**Remark** - if you want to pass custom properties, you should still use snake_cased keys.
+
+
+## Advanced
+To reduce the amount of re-renders in your React application I suggest to make use of [`React.useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback). TLDR: `useCallback` will return a memoized version of the callback that only changes if one of the dependencies has changed.
+This can be applied to both the `IntercomProvider` events and the `useIntercom` methods. It depends on how many times you main app gets re-rendered.
+
+### Example
+```javascript
+import * as React from 'react';
+
+import { IntercomProvider, useIntercom } from '../../../dist';
+
+const INTERCOM_APP_ID = 'your-intercom-app-id';
+
+
+const App = () => {
+  // const onHide = () => console.log('Intercom did hide the Messenger');
+  const onHide = React.useCallback(
+    () => console.log('Intercom did hide the Messenger'),
+    [],
+  );
+
+  return (
+    <IntercomProvider appId={INTERCOM_APP_ID} onHide={onHide}>
+      <HomePage />
+    </IntercomProvider>
+  );
+};
+
+const HomePage = () => {
+  const { boot } = useIntercom();
+
+  // const bootWithProps = () => boot({ name: 'Russo' });
+  const bootWithProps = React.useCallback(() => boot({ name: 'Russo' }), [boot]);
+
+  return <button onClick={bootWithProps}>Boot with props</button>;
+};
 ```

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -1,53 +1,55 @@
 import * as React from 'react';
-import styled, { createGlobalStyle } from 'styled-components';
+import styled from 'styled-components';
 import { BrowserRouter as Router, Route, NavLink } from 'react-router-dom';
-import { normalize } from 'styled-normalize';
 
 import { ProviderPage, UseIntercomPage } from './modules';
 
-const GlobalStyle = createGlobalStyle`
-  ${normalize}
-
-  html {
-    font-size: 15px;
-  }
-
-  body {
-    font-family: 'Hind', Helvetica, sans-serif;
-  }
-
-  code {
-    font-family: 'Fira Code', monospace;
-    font-size: 0.95rem;
-  }
-`;
+import { Page, Style } from './modules/common';
 
 const Navigation = styled.ul`
   padding: 0;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-row-gap: 1.75rem;
+`;
+
+const Link = styled(NavLink)`
+  text-decoration: none;
+  color: var(--dark);
+
+  &:visited,
+  &:active {
+    text-decoration: none;
+  }
+
+  > code {
+    font-size: 1rem;
+  }
 `;
 
 const App = () => {
   return (
     <>
-      <GlobalStyle />
-      <h1>react-use-intercom</h1>
-      <p>This main page contains short desc of the library</p>
-      <Router>
-        <Route path="/provider" component={ProviderPage} />
-        <Route path="/useIntercom" component={UseIntercomPage} />
-        <Route path="/" exact>
-          <Navigation>
-            <NavLink to="/provider">
-              <code>IntercomProvider</code>
-            </NavLink>
-            <NavLink to="/useIntercom">
-              <code>useIntercom</code>
-            </NavLink>
-          </Navigation>
-        </Route>
-      </Router>
+      <Style />
+      <Page
+        title="react-use-intercom"
+        description="Example playground to showcase the functionalities of this package"
+      >
+        <Router>
+          <Route path="/provider" component={ProviderPage} />
+          <Route path="/useIntercom" component={UseIntercomPage} />
+          <Route path="/" exact>
+            <Navigation>
+              <Link to="/provider">
+                <code>IntercomProvider</code>
+              </Link>
+              <Link to="/useIntercom">
+                <code>useIntercom</code>
+              </Link>
+            </Navigation>
+          </Route>
+        </Router>
+      </Page>
     </>
   );
 };

--- a/example/modules/common/button.tsx
+++ b/example/modules/common/button.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+type Props = {
+  label: string;
+} & React.HTMLAttributes<HTMLButtonElement>;
+
+const Container = styled.button`
+  width: fit-content;
+  min-width: 8rem;
+  border: none;
+  padding: 0.75rem 1.55rem;
+  border-radius: 6px;
+  color: white;
+  font-size: 0.9rem;
+  font-weight: 700;
+  background-color: var(--dark);
+  cursor: pointer;
+
+  &:active,
+  &:focus,
+  &:hover {
+    background-image: linear-gradient(to right, #45e87b, #05e1f9);
+  }
+`;
+
+const Button = ({ label, ...rest }: Props) => (
+  <Container {...rest}>{label}</Container>
+);
+
+export default Button;

--- a/example/modules/common/index.ts
+++ b/example/modules/common/index.ts
@@ -1,0 +1,3 @@
+export { default as Button } from './button';
+export { default as Page } from './page';
+export { default as Style } from './style';

--- a/example/modules/common/page.tsx
+++ b/example/modules/common/page.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+type Props = {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+};
+
+const Container = styled.main`
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 0;
+`;
+
+const Wrapper = styled.div`
+  max-width: 1024px;
+  padding: 0 2rem;
+  width: 100%;
+`;
+
+const Body = styled.div`
+  margin-top: 2rem;
+`;
+
+const Description = styled.div`
+  color: var(--dark);
+  font-size: 1.1rem;
+  font-weight: 400;
+`;
+
+const Divider = styled.div`
+  height: 2px;
+  width: 5%;
+  background-image: linear-gradient(to right, #45e87b, #05e1f9);
+  margin: 2.5rem 0;
+`;
+
+const Page = ({ title, description, children }: Props) => {
+  return (
+    <Container>
+      <Wrapper>
+        <h1>{title}</h1>
+        <Description>{description}</Description>
+        <Divider />
+        <Body>{children}</Body>
+      </Wrapper>
+    </Container>
+  );
+};
+
+export default Page;

--- a/example/modules/common/style.tsx
+++ b/example/modules/common/style.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { createGlobalStyle } from 'styled-components';
+import { Normalize } from 'styled-normalize';
+
+const GlobalStyle = createGlobalStyle`
+  :root {
+    --light: #ffffff;
+    --dark: #181818;
+    --cyan: #6afdef;
+    --grey: #f4f0eb;
+  }
+
+  html {
+    font-size: 15px;
+  }
+
+  h1, 
+  h2, 
+  h3,
+  h4,
+  h5,
+  h6,
+  p {
+    color: var(--dark)
+  }
+
+  body {
+    font-family: 'Hind', Helvetica, sans-serif;
+  }
+
+  code {
+    background: var(--grey);
+    border-radius: 2px;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.825rem;
+    padding: 0.075rem 0.35rem;
+  }
+`;
+
+const Style = () => (
+  <>
+    <Normalize />
+    <GlobalStyle />
+  </>
+);
+
+export default Style;

--- a/example/modules/provider/provider.tsx
+++ b/example/modules/provider/provider.tsx
@@ -4,12 +4,9 @@ import { IntercomProvider } from '../../../.';
 
 const Provider = () => {
   return (
-    <>
-      <h3>IntercomProvider</h3>
-      <IntercomProvider appId="jcabc7e3" autoBoot>
-        <p>Intercom children</p>
-      </IntercomProvider>
-    </>
+    <IntercomProvider appId="jcabc7e3">
+      <p>Intercom children</p>
+    </IntercomProvider>
   );
 };
 

--- a/example/modules/useIntercom/useIntercom.tsx
+++ b/example/modules/useIntercom/useIntercom.tsx
@@ -3,34 +3,27 @@ import styled from 'styled-components';
 
 import { IntercomProvider, useIntercom } from '../../../.';
 
+import { Button } from '../common';
+
 const Grid = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-gap: 1rem;
+  grid-template-columns: repeat(1, 1fr);
+  width: 100%;
 `;
 
-const Button = styled.button`
-  border: none;
-  padding: 1rem 3rem;
-  border-radius: 10px;
-  color: white;
-  text-transform: uppercase;
-  letter-spacing: 1.25px;
-  word-spacing: 1px;
-  font-size: 0.8rem;
-  font-weight: 500;
-  background-image: linear-gradient(to right, #48a4fb, #05e1f9);
-  cursor: pointer;
+const Item = styled.div`
+  display: grid;
+  grid-template-rows: min-content;
 
-  &:active,
-  &:focus,
-  &:hover {
-    background-image: linear-gradient(to right, #45e87b, #45f3dc);
+  &::after {
+    content: '';
+    margin: 2rem 0 1.5rem;
+    border-bottom: 2px solid var(--grey);
+    width: 100%;
   }
-  /* background-image: linear-gradient(to right, #45e87b, #45f3dc); */
 `;
 
-const UseIntercomChildPage = () => {
+const RawUseIntercomPage = () => {
   const {
     boot,
     shutdown,
@@ -82,59 +75,125 @@ const UseIntercomChildPage = () => {
 
   return (
     <Grid>
-      <Button data-cy="boot" onClick={boot}>
-        Boot clean intercom
-      </Button>
-      <Button data-cy="boot-seeded" onClick={handleBoot}>
-        Boot seeded intercom
-      </Button>
-      <Button data-cy="shutdown" onClick={shutdown}>
-        Shutdown intercom
-      </Button>
-      <Button data-cy="shutdown-hard" onClick={hardShutdown}>
-        Hard Shutdown intercom
-      </Button>
-      <Button data-cy="update" onClick={update}>
-        Update clean session
-      </Button>
-      <Button data-cy="update-seeded" onClick={handleUpdate}>
-        Update session with options
-      </Button>
-      <Button data-cy="show" onClick={show}>
-        Show messages
-      </Button>
-      <Button data-cy="hide" onClick={hide}>
-        Hide messages
-      </Button>
-      <Button data-cy="show-messages" onClick={showMessages}>
-        Show messages list
-      </Button>
-      <Button data-cy="show-new-messages" onClick={handleNewMessages}>
-        Show new messages
-      </Button>
-      <Button
-        data-cy="show-messages-content"
-        onClick={handleNewMessagesWithContent}
-      >
-        Show new messages with content
-      </Button>
-      <Button data-cy="visitorId" onClick={handleGetVisitorId}>
-        Get visitor id
-      </Button>
-      <Button onClick={handleStartTour}>Start tour (wont work)</Button>
-      <Button onClick={handleTrackEvent}>Track event</Button>
-      <Button onClick={handleTrackEventWithMetaData}>
-        Track event with metadata
-      </Button>
+      <Item>
+        <p>
+          boots the Intercom instance, not needed if <code>autoBoot</code> in{' '}
+          <code>IntercomProvider</code> is <code>true</code>
+        </p>
+        <Button label="Boot" data-cy="boot" onClick={boot} />
+      </Item>
+      <Item>
+        <p>
+          boots the Intercom instance with given <code>props</code>
+        </p>
+        <Button label="Boot props" data-cy="boot-seeded" onClick={handleBoot} />
+      </Item>
+      <Item>
+        <p>shuts down the Intercom instance</p>
+        <Button label="Shutdown" data-cy="shutdown" onClick={shutdown} />
+      </Item>
+      <Item>
+        <p>
+          same functionality as <code>shutdown</code>, but makes sure the
+          Intercom cookies, <code>window.Intercom</code> and{' '}
+          <code>window.intercomSettings</code> are removed
+        </p>
+        <Button
+          label="Shutdown hard"
+          data-cy="shutdown-hard"
+          onClick={hardShutdown}
+        />
+      </Item>
+      <Item>
+        <p>Initiates a 'ping'</p>
+        <Button label="Update" data-cy="update" onClick={update} />
+      </Item>
+      <Item>
+        <p>
+          updates the Intercom instance with the supplied <code>props</code>
+        </p>
+        <Button
+          label="Update with props"
+          data-cy="update-seeded"
+          onClick={handleUpdate}
+        />
+      </Item>
+      <Item>
+        <p>shows the Messenger</p>
+        <Button label="Show" data-cy="show" onClick={show} />
+      </Item>
+      <Item>
+        <p>hides the Messenger</p>
+        <Button label="Hide messages" data-cy="hide" onClick={hide} />
+      </Item>
+      <Item>
+        <p>shows the Messenger with the message list</p>
+        <Button
+          label="Show messages"
+          data-cy="show-messages"
+          onClick={showMessages}
+        />
+      </Item>
+      <Item>
+        <p>shows the Messenger as if a new conversation was just created.</p>
+        <Button
+          label="Show new messages"
+          data-cy="show-new-messages"
+          onClick={handleNewMessages}
+        />
+      </Item>
+      <Item>
+        <p>
+          hows the Messenger as if a new conversation was just created with the
+          prefilled content
+        </p>
+        <Button
+          label="Show new messages with content"
+          data-cy="show-messages-content"
+          onClick={handleNewMessagesWithContent}
+        />
+      </Item>
+      <Item>
+        <p>gets the visitor id </p>
+        <Button
+          label="Get visitor id"
+          data-cy="visitorId"
+          onClick={handleGetVisitorId}
+        />
+      </Item>
+      <Item>
+        <p>
+          starts a tour based on the <code>tourId</code>
+        </p>
+        <Button label="Start tour" onClick={handleStartTour}>
+          Start tour
+        </Button>
+      </Item>
+      <Item>
+        <p>
+          submits an <code>event</code>{' '}
+        </p>
+        <Button label="Track event" onClick={handleTrackEvent} />
+      </Item>
+      <Item>
+        <p>
+          submits an <code>event</code> with <code>metadata</code>
+        </p>
+        <Button
+          label="Track event with metadata"
+          onClick={handleTrackEventWithMetaData}
+        />
+      </Item>
+
       {visitorId && <p data-cy="visitorIdValue">{visitorId}</p>}
     </Grid>
   );
 };
 
-const UseIntercomPage = ({ children }: any) => {
+const UseIntercomPage = () => {
   return (
     <IntercomProvider appId="jcabc7e3">
-      <UseIntercomChildPage />
+      <RawUseIntercomPage />
     </IntercomProvider>
   );
 };

--- a/example/package.json
+++ b/example/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "example",
+  "name": "react-use-intercom-example-playground",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "private": true,
   "scripts": {
     "start": "parcel index.html",
     "build": "parcel build index.html"

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,19 +1,26 @@
 import { createContext } from 'react';
 
+import * as logger from './logger';
 import { IntercomContextValues } from './contextTypes';
 
+const NO_INTERCOM_PROVIDER_MESSAGE =
+  'Please wrap your component with `IntercomProvider`.';
+
 const IntercomContext = createContext<IntercomContextValues>({
-  boot: () => null,
-  shutdown: () => null,
-  hardShutdown: () => null,
-  update: () => null,
-  hide: () => null,
-  show: () => null,
-  showMessages: () => null,
-  showNewMessages: () => null,
-  getVisitorId: () => '',
-  startTour: () => null,
-  trackEvent: () => null,
+  boot: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
+  shutdown: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
+  hardShutdown: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
+  update: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
+  hide: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
+  show: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
+  showMessages: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
+  showNewMessages: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
+  getVisitorId: () => {
+    logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE);
+    return '';
+  },
+  startTour: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
+  trackEvent: () => logger.log('error', NO_INTERCOM_PROVIDER_MESSAGE),
 });
 
 export default IntercomContext;

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -146,6 +146,5 @@ export type IntercomProviderProps = {
    * This method allows you to register a function that will be called immediately
    * when invoked, and again whenever the current number of unread messages changes.
    */
-  onUnreadCountChange?: Function;
-  // TODO: logging prop
+  onUnreadCountChange?: (unreadCount: number) => void;
 };

--- a/test/useIntercom.test.tsx
+++ b/test/useIntercom.test.tsx
@@ -16,13 +16,6 @@ declare global {
 }
 
 describe('useIntercom', () => {
-  test('should not be available when not wrapped in context', () => {
-    const { result } = renderHook(() => useIntercom());
-
-    expect(result.current.boot()).toBeNull();
-    expect(result.current.hide()).toBeNull();
-  });
-
   test('should be available when wrapped in context', () => {
     const { result } = renderHook(() => useIntercom(), {
       wrapper: ({ children }) => (


### PR DESCRIPTION
Update readme with `react-use-intercom` features.

* Add `example` playground. This is both used for e2e tests and playground. Maybe in the future these two should be seperated.
* Add `console.error` when `useIntercom` was called and no `IntercomProvider` was supplied.