### PR TITLE
feature: improve error logging in intercom provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,11 @@ const HomePage = () => {
 ## Playground
 Example playground to showcase the functionalities of `react-use-intercom`. 
 
+### useIntercom
 [https://devrnt.github.io/react-use-intercom/#/useIntercom](https://devrnt.github.io/react-use-intercom/#/useIntercom)
+
+### useIntercom (with Intercom tour)
+[https://devrnt.github.io/react-use-intercom/#/useIntercomTour](https://devrnt.github.io/react-use-intercom/#/useIntercomTour)
 
 ## TypeScript
 All the possible pre-defined options to pass to the Intercom instance are typed. So whenever you have to pass [IntercomProps](src/types.ts), all the possible properties will be available out of the box.

--- a/example/modules/useIntercom/useIntercomTour.tsx
+++ b/example/modules/useIntercom/useIntercomTour.tsx
@@ -29,8 +29,7 @@ const RawUseIntercomStartPagePage = () => {
   const handleBoot = React.useCallback(() => boot({ name: 'Russo' }), [boot]);
 
   const handleStartTour = React.useCallback(() => {
-    // TODO: update tour id
-    startTour(122198);
+    startTour(124247);
   }, [startTour]);
 
   return (

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -7,6 +7,7 @@ import { IntercomContextValues, IntercomProviderProps } from './contextTypes';
 import { IntercomAPI } from './intercom';
 import { IntercomProps, RawIntercomBootProps } from './types';
 import { mapIntercomPropsToRawIntercomProps } from './mappers';
+import { isEmptyObject } from './utils';
 
 export const IntercomProvider = ({
   appId,
@@ -15,7 +16,17 @@ export const IntercomProvider = ({
   onHide,
   onShow,
   onUnreadCountChange,
+  ...rest
 }: IntercomProviderProps) => {
+  if (!isEmptyObject(rest))
+    logger.log(
+      'error',
+      [
+        'some invalid props were passed to IntercomProvider. ',
+        `Please check following props: ${Object.keys(rest).join(', ')}.`,
+      ].join(''),
+    );
+
   const [isBooted, setIsBooted] = useState(autoBoot);
 
   if (!window.Intercom) {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,0 +1,2 @@
+export const isEmptyObject = (obj: object) =>
+  Object.keys(obj).length === 0 && obj.constructor === Object;


### PR DESCRIPTION
Passing "not allowed" props to `IntercomProvider` will cause a `console.error`.

Closes #11 