### PR TITLE
refactor: improve logging and cleanup

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -8,10 +8,12 @@ import { IntercomMethod } from './types';
  * @param args arguments passed to the `window.Intercom` instance
  * @see {@link https://developers.intercom.com/installing-intercom/docs/intercom-javascript}
  */
-export const IntercomAPI = (method: IntercomMethod, ...args: Array<any>) => {
+const IntercomAPI = (method: IntercomMethod, ...args: Array<any>) => {
   if (window.Intercom) {
     return window.Intercom.apply(null, [method, ...args]);
   } else {
     logger.log('error', `${method} Intercom instance is not initalized yet`);
   }
 };
+
+export default IntercomAPI;

--- a/src/intercom.ts
+++ b/src/intercom.ts
@@ -1,3 +1,4 @@
+import * as logger from './logger';
 import { IntercomMethod } from './types';
 
 /**
@@ -11,6 +12,6 @@ export const IntercomAPI = (method: IntercomMethod, ...args: Array<any>) => {
   if (window.Intercom) {
     return window.Intercom.apply(null, [method, ...args]);
   } else {
-    console.warn('[intercom] Intercom instance is not initialized yet');
+    logger.log('error', `${method} Intercom instance is not initalized yet`);
   }
 };

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import * as logger from './logger';
+import IntercomAPI from './api';
 import initialize from './initialize';
 import IntercomContext from './context';
 import { IntercomContextValues, IntercomProviderProps } from './contextTypes';
-import { IntercomAPI } from './intercom';
 import { IntercomProps, RawIntercomBootProps } from './types';
 import { mapIntercomPropsToRawIntercomProps } from './mappers';
 import { isEmptyObject } from './utils';


### PR DESCRIPTION
* Use custom logger instead of logging directly with `console.log`
* Add extra logging when `shouldInitialize` is set to `false` in `IntercomProvider`. Log a warning to let the developer know that the `IntercomProvider` was explicitly not initialized.
* Rename `intercom.tsx` to `api.tsx` and use `default` export/import