### PR TITLE
fix: safeguards against SSR environments without access to window

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,15 +1,17 @@
 import * as logger from './logger';
 import { IntercomMethod } from './types';
+import { isSSR } from './utils';
 
 /**
  * Safely exposes `window.Intercom` and passes the arguments to the instance
  *
  * @param method method passed to the `window.Intercom` instance
  * @param args arguments passed to the `window.Intercom` instance
+ *
  * @see {@link https://developers.intercom.com/installing-intercom/docs/intercom-javascript}
  */
 const IntercomAPI = (method: IntercomMethod, ...args: Array<any>) => {
-  if (window.Intercom) {
+  if (!isSSR && window.Intercom) {
     return window.Intercom.apply(null, [method, ...args]);
   } else {
     logger.log('error', `${method} Intercom instance is not initalized yet`);

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -48,7 +48,6 @@ export const IntercomProvider = ({
 
   const ensureIntercom = React.useCallback(
     (functionName: string = 'A function', callback: Function) => {
-      if (isSSR) return;
       if (!window.Intercom && !memoizedShouldInitialize.current) {
         logger.log(
           'warn',
@@ -73,7 +72,6 @@ export const IntercomProvider = ({
   );
 
   const boot = React.useCallback((props?: IntercomProps) => {
-    if (isSSR) return;
     if (!window.Intercom && !memoizedShouldInitialize.current) {
       logger.log(
         'warn',
@@ -94,14 +92,14 @@ export const IntercomProvider = ({
   }, []);
 
   const shutdown = React.useCallback(() => {
-    if (isSSR || !isBooted.current) return;
+    if (!isBooted.current) return;
 
     IntercomAPI('shutdown');
     isBooted.current = false;
   }, []);
 
   const hardShutdown = React.useCallback(() => {
-    if (isSSR || !isBooted.current) return;
+    if (!isBooted.current) return;
 
     IntercomAPI('shutdown');
     delete window.Intercom;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,2 +1,4 @@
 export const isEmptyObject = (obj: object) =>
   Object.keys(obj).length === 0 && obj.constructor === Object;
+
+export const isSSR = typeof window === 'undefined';


### PR DESCRIPTION
This PR checks for `typeof window === 'undefined'` to safeguard against any usage of window if it is not present. 

This module will now work in SSRd environments such as Next.js.

Thanks for the meticulously typed package 👍 