### PR TITLE
fix: allows customAttributes to be passed to company records

### DIFF
--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -79,6 +79,7 @@ const mapDataAttributesCompanyToRawDataAttributesCompany = (
   size: attributes.size,
   website: attributes.website,
   industry: attributes.industry,
+  ...attributes.customAttributes,
 });
 
 const mapRawDataAttributesAvatarToDataAttributesAvatar = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,8 @@ export type DataAttributesCompany = {
   website?: string;
   /** The industry of the company */
   industry?: string;
+  /** Custom attributes */
+  customAttributes?: Record<string, any>;
 };
 
 export type RawDataAttributesAvatar = {
@@ -132,12 +134,12 @@ export type RawDataAttributes = {
 
 export type DataAttributes = {
   /** The email address of the currently logged in user
-   * 
+   *
   @remarks Only applicable to users
   */
   email?: string;
   /** The user ID of the currently logged in user
-   * 
+   *
   @remarks Only applicable to users
   */
   userId?: string;


### PR DESCRIPTION
This PR allows custom attributes to be passed to companies.

In general, I think this library would be better without the mapping logic, as the serialization to & from snakeCase/camelCase is an unnecessary complication.