### PR TITLE
chore: only show logs in development mode

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,19 +7,21 @@ import { LogLevel } from './types';
  * @param message the message to log in the console
  */
 export const log = (level: LogLevel, message: string) => {
-  const packageName = '[react-use-intercom]';
+  if (__DEV__) {
+    const packageName = '[react-use-intercom]';
 
-  switch (level) {
-    case 'info':
-      console.log(`${packageName} ${message}`);
-      break;
-    case 'warn':
-      console.warn(`${packageName} ${message}`);
-      break;
-    case 'error':
-      console.error(`${packageName} ${message}`);
-      break;
-    default:
-      console.log(`${packageName} ${message}`);
+    switch (level) {
+      case 'info':
+        console.log(`${packageName} ${message}`);
+        break;
+      case 'warn':
+        console.warn(`${packageName} ${message}`);
+        break;
+      case 'error':
+        console.error(`${packageName} ${message}`);
+        break;
+      default:
+        console.log(`${packageName} ${message}`);
+    }
   }
 };


### PR DESCRIPTION
Make use of [babel-plugin-dev-expression]( https://github.com/4Catalyzer/babel-plugin-dev-expression#readme) to only show logs in development mode.

This result in a production bundle without the (development) logs. As well as a bundlesize reduction of 0.28kB