### PR TITLE
Improve initialize()

### DIFF
--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -30,7 +30,10 @@ const initialize = (appId: string) => {
       var x = d.getElementsByTagName('script')[0];
       x.parentNode.insertBefore(s, x);
     };
-    if (w.attachEvent) {
+    if (document.readyState === 'complete') {
+      l();
+    } 
+    else if (w.attachEvent) {
       w.attachEvent('onload', l);
     } else {
       w.addEventListener('load', l, false);

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -32,8 +32,7 @@ const initialize = (appId: string) => {
     };
     if (document.readyState === 'complete') {
       l();
-    } 
-    else if (w.attachEvent) {
+    } else if (w.attachEvent) {
       w.attachEvent('onload', l);
     } else {
       w.addEventListener('load', l, false);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -2,5 +2,14 @@
 // @ts-nocheck
 import { JSDOM } from 'jsdom';
 const dom = new JSDOM();
+
+// FIXME: Override readyState since this is not fired
+// Will be 'completed' in tests
+// https://github.com/jsdom/jsdom/issues/1436
+Object.defineProperty(document, 'readyState', {
+  get() {
+    return 'loading';
+  },
+});
 global.document = dom.window.document;
 global.window = dom.window;


### PR DESCRIPTION
If `IntercomProvider` is placed deeper inside the component tree, it is very likely that window load event was already fired before initialize() had a chance to add the event listener. Check for document.readyState to attach the intercom script even if the page was already loaded.