### PR TITLE
Remove existing intercom check

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -36,7 +36,7 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
       ].join(''),
     );
 
-  if (!isSSR && !window.Intercom && shouldInitialize) {
+  if (!isSSR && shouldInitialize) {
     initialize(appId, initializeDelay);
     // Only add listeners on initialization
     if (onHide) IntercomAPI('onHide', onHide);
@@ -61,7 +61,7 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
       functionName: string = 'A function',
       callback: (() => void) | (() => string),
     ) => {
-      if (!window.Intercom && !shouldInitialize) {
+      if (!shouldInitialize) {
         logger.log(
           'warn',
           'Intercom instance is not initialized because `shouldInitialize` is set to `false` in `IntercomProvider`',
@@ -86,7 +86,7 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
 
   const boot = React.useCallback(
     (props?: IntercomProps) => {
-      if (!window.Intercom && !shouldInitialize) {
+      if (!shouldInitialize) {
         logger.log(
           'warn',
           'Intercom instance is not initialized because `shouldInitialize` is set to `false` in `IntercomProvider`',


### PR DESCRIPTION
## Summary
This allows react-use-intercom to "hook" onto an existing instance of Intercom, e.g., loaded in by another platform such as [Segment](https://segment.com/), and attach your own event listeners to that instance with this library.

This is safe since the `initialize` script already the job of checking if an existing instance exists. If it finds an existing instance, it'll just re-attach to that instance and call update with the latest `window.intercomSettings`.

## Test
test both cases:
- react-use-intercom is initialized before the external platform (Segment) initializes Intercom
- the external platform (Segment) executes and boots Intercom before react-use-intercom

