### PR TITLE
Support attaching to an existing Intercom instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * Documented, self explaining methods 
 * [Tiny size](https://bundlephobia.com/result?p=react-use-intercom@latest) without any external libraries
 * Safeguard for SSR environments (NextJS, Gatsby)
+* Compatible to hook into existing Intercom intance (loaded by [Segment](https://segment.com/))
 
 ## Installation
 

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -9,6 +9,7 @@ import {
   IntercomContextValues,
   IntercomProps,
   IntercomProviderProps,
+  RawIntercomBootProps,
 } from './types';
 import { isEmptyObject, isSSR } from './utils';
 
@@ -48,7 +49,7 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
 
       if (isBooted.current) return;
 
-      const metaData = {
+      const metaData: RawIntercomBootProps = {
         app_id: appId,
         ...(apiBase && { api_base: apiBase }),
         ...(props && mapIntercomPropsToRawIntercomProps(props)),

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -72,7 +72,7 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
     [apiBase, appId, shouldInitialize],
   );
 
-  if (!isSSR && shouldInitialize) {
+  if (!isSSR && shouldInitialize && !isBooted.current) {
     initialize(appId, initializeDelay);
     attachListeners();
     if (autoBoot) boot();

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -25,6 +25,7 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
   ...rest
 }) => {
   const isBooted = React.useRef(false);
+  const isInitialized = React.useRef(false);
 
   if (!isEmptyObject(rest) && __DEV__)
     logger.log(
@@ -34,21 +35,6 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
         `Please check following props: ${Object.keys(rest).join(', ')}.`,
       ].join(''),
     );
-
-  const isInitialized = React.useRef(false);
-  const init = React.useCallback(() => {
-    if (!isInitialized.current) {
-      initialize(appId, initializeDelay);
-
-      // attach listeners
-      if (onHide) IntercomAPI('onHide', onHide);
-      if (onShow) IntercomAPI('onShow', onShow);
-      if (onUnreadCountChange)
-        IntercomAPI('onUnreadCountChange', onUnreadCountChange);
-
-      isInitialized.current = true;
-    }
-  }, [appId, initializeDelay, onHide, onShow, onUnreadCountChange]);
 
   const boot = React.useCallback(
     (props?: IntercomProps) => {
@@ -75,9 +61,18 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
     [apiBase, appId, shouldInitialize],
   );
 
-  if (!isSSR && shouldInitialize) {
-    init();
+  if (!isSSR && shouldInitialize && !isInitialized.current) {
+    initialize(appId, initializeDelay);
+
+    // attach listeners
+    if (onHide) IntercomAPI('onHide', onHide);
+    if (onShow) IntercomAPI('onShow', onShow);
+    if (onUnreadCountChange)
+      IntercomAPI('onUnreadCountChange', onUnreadCountChange);
+
     if (autoBoot) boot();
+
+    isInitialized.current = true;
   }
 
   const ensureIntercom = React.useCallback(


### PR DESCRIPTION
## Summary
This allows react-use-intercom to "hook" onto an existing instance of Intercom, e.g., loaded in by another platform such as [Segment](https://segment.com/).

## Test
- react-use-intercom should control an existing Intercom instance
- listeners should not be re-attached when the provider re-renders