### PR TITLE
fix: remove useless jsdoc

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -146,7 +146,6 @@ export type DataAttributes = {
   /** The Unix timestamp (in seconds) when the user signed up to your app
    *
    * @remarks Only applicable to users
-   * @see {@link https://www.w3schools.com/cssref/css_colors.asp}
    */
   createdAt?: string;
   /** Name of the current user/lead */


### PR DESCRIPTION
Remove useless jsdoc link for the `createdAt` field

Fixes #340 