### PR TITLE
expose intercom JS API 'showArticle' function through useIntercom

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 | getVisitorId    | () => string                               | gets the visitor id                                                                                                                 |
 | startTour       | (tourId: number) => void                   | starts a tour based on the `tourId`                                                                                                 |
 | trackEvent      | (event: string, metaData?: object) => void | submits an `event` with optional `metaData`      
+| showArticle      | (articleId: string) => void | opens the Messenger with the specified article by `articleId`
 
 #### Example
 ```javascript
@@ -154,6 +155,7 @@ const HomePage = () => {
     getVisitorId,
     startTour,
     trackEvent,
+    showArticle
   } = useIntercom();
 
   const bootWithProps = () => boot({ name: 'Russo' });
@@ -167,6 +169,7 @@ const HomePage = () => {
     trackEvent('invited-frind', {
       name: 'Russo',
     });
+  const handleShowArticle = () => showArticle(123456);
 
   return (
     <>
@@ -189,6 +192,7 @@ const HomePage = () => {
       <button onClick={handleTrackEventWithMetaData}>
         Track event with metadata
       </button>
+      <button onClick={handleShowArticle}>Open article in Messenger</button>
     </>
   );
 };

--- a/playground/modules/useIntercom/useIntercom.tsx
+++ b/playground/modules/useIntercom/useIntercom.tsx
@@ -258,7 +258,7 @@ const RawUseIntercomPage = () => {
       </Item>
       <Item>
         <p>
-          opens an article with the given <code>article ID</code>
+          opens an article with the given <code>articleId</code>
         </p>
         <Button label="Open article" onClick={handleShowArticle} />
       </Item>

--- a/playground/modules/useIntercom/useIntercom.tsx
+++ b/playground/modules/useIntercom/useIntercom.tsx
@@ -134,7 +134,7 @@ const RawUseIntercomPage = () => {
   }, [trackEvent]);
 
   const handleShowArticle = React.useCallback(() => {
-    showArticle(123);
+    showArticle(4013997);
   }, [showArticle]);
 
   const [visitorId, setVisitorId] = React.useState<string | null>(null);
@@ -260,7 +260,7 @@ const RawUseIntercomPage = () => {
         <p>
           opens an article with the given <code>article ID</code>
         </p>
-        <Button label="Track event with metadata" onClick={handleShowArticle} />
+        <Button label="Open article" onClick={handleShowArticle} />
       </Item>
 
       {visitorId && <p data-cy="visitorIdValue">{visitorId}</p>}

--- a/playground/modules/useIntercom/useIntercom.tsx
+++ b/playground/modules/useIntercom/useIntercom.tsx
@@ -34,6 +34,7 @@ const RawUseIntercomPage = () => {
     showNewMessages,
     getVisitorId,
     trackEvent,
+    showArticle,
   } = useIntercom();
   const handleBoot = React.useCallback(() => boot(), [boot]);
 
@@ -131,6 +132,10 @@ const RawUseIntercomPage = () => {
   const handleTrackEventWithMetaData = React.useCallback(() => {
     trackEvent('invited-friend', { name: 'Russo' });
   }, [trackEvent]);
+
+  const handleShowArticle = React.useCallback(() => {
+    showArticle(123);
+  }, [showArticle]);
 
   const [visitorId, setVisitorId] = React.useState<string | null>(null);
 
@@ -250,6 +255,12 @@ const RawUseIntercomPage = () => {
           label="Track event with metadata"
           onClick={handleTrackEventWithMetaData}
         />
+      </Item>
+      <Item>
+        <p>
+          opens an article with the given <code>article ID</code>
+        </p>
+        <Button label="Track event with metadata" onClick={handleShowArticle} />
       </Item>
 
       {visitorId && <p data-cy="visitorIdValue">{visitorId}</p>}

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -204,6 +204,14 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
     [ensureIntercom],
   );
 
+  const showArticle = React.useCallback(
+    (articleId: number) =>
+      ensureIntercom('showArticle', () => {
+        IntercomAPI('showArticle', articleId);
+      }),
+    [ensureIntercom],
+  );
+
   const providerValue = React.useMemo<IntercomContextValues>(() => {
     return {
       boot,
@@ -217,6 +225,7 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
       getVisitorId,
       startTour,
       trackEvent,
+      showArticle,
     };
   }, [
     boot,
@@ -230,6 +239,7 @@ export const IntercomProvider: React.FC<IntercomProviderProps> = ({
     getVisitorId,
     startTour,
     trackEvent,
+    showArticle,
   ]);
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -378,7 +378,7 @@ export type IntercomContextValues = {
    */
   trackEvent: (event: string, metaData?: object) => void;
   /**
-   * Opens the messenger with the specified article open
+   * Opens the messenger with the specified article
    *
    * @see {@link https://developers.intercom.com/installing-intercom/docs/intercom-javascript#intercomshowarticle-articleid}
    *

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,7 +239,8 @@ export type IntercomMethod =
   | 'onUnreadCountChange'
   | 'trackEvent'
   | 'getVisitorId'
-  | 'startTour';
+  | 'startTour'
+  | 'showArticle';
 
 export type RawIntercomProps = RawMessengerAttributes & RawDataAttributes;
 
@@ -376,6 +377,14 @@ export type IntercomContextValues = {
    * ```
    */
   trackEvent: (event: string, metaData?: object) => void;
+  /**
+   * Opens the messenger with the specified article open
+   *
+   * @see {@link https://developers.intercom.com/installing-intercom/docs/intercom-javascript#intercomshowarticle-articleid}
+   *
+   * @remarks if an article with the given ID doesn't exits, Messenger Home is opened instead
+   */
+  showArticle: (articleId: number) => void;
 };
 
 export type IntercomProviderProps = {


### PR DESCRIPTION
The Intercom Javascript API now supports opening an article in the Messenger widget (see: https://developers.intercom.com/installing-intercom/docs/intercom-javascript#intercomshowarticle-articleid)

This PR exposes that API through the useIntercom hook.