### PR TITLE
Add PropsWithChildren React type

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -13,7 +13,9 @@ import {
 } from './types';
 import { isEmptyObject, isSSR } from './utils';
 
-export const IntercomProvider: React.FC<IntercomProviderProps> = ({
+export const IntercomProvider: React.FC<React.PropsWithChildren<
+  IntercomProviderProps
+>> = ({
   appId,
   autoBoot = false,
   autoBootProps,


### PR DESCRIPTION
Fix TypeScript react type. This would result in TypeScript issues when using with the React 18 types, see https://twitter.com/reactjs/status/1512453969490108418

https://github.com/devrnt/react-use-wizard/pull/115