### PR TITLE
feat: add isOpen flag to useIntercom()

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,12 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 
  Make sure `IntercomProvider` is wrapped around your component when calling `useIntercom()`. 
 
-**Remark** - You can't use `useIntercom()` in the same component where `IntercomProvider` is initialized. 
+**Remark** - You can't use `useIntercom()` in the same component where `IntercomProvider` is initialized.
+
+#### State
+| name                | type             | description                                                                             |
+|---------------------|------------------|-----------------------------------------------------------------------------------------|
+| isOpen              | boolean          | the visibility status of the messenger                                                  |
 
 #### Methods
 | name            | type                                       | description                                                                                                                         |

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -75,12 +75,24 @@ export const IntercomProvider: React.FC<React.PropsWithChildren<
     [apiBase, appId, shouldInitialize],
   );
 
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const onHideWrapper = React.useCallback(() => {
+    setIsOpen(false);
+    if (onHide) onHide();
+  }, [onHide, setIsOpen]);
+
+  const onShowWrapper = React.useCallback(() => {
+    setIsOpen(true);
+    if (onShow) onShow();
+  }, [onShow, setIsOpen]);
+
   if (!isSSR && shouldInitialize && !isInitialized.current) {
     initialize(appId, initializeDelay);
 
     // attach listeners
-    if (onHide) IntercomAPI('onHide', onHide);
-    if (onShow) IntercomAPI('onShow', onShow);
+    IntercomAPI('onHide', onHideWrapper);
+    IntercomAPI('onShow', onShowWrapper);
     if (onUnreadCountChange)
       IntercomAPI('onUnreadCountChange', onUnreadCountChange);
 
@@ -231,6 +243,7 @@ export const IntercomProvider: React.FC<React.PropsWithChildren<
       update,
       hide,
       show,
+      isOpen,
       showMessages,
       showNewMessages,
       getVisitorId,
@@ -245,6 +258,7 @@ export const IntercomProvider: React.FC<React.PropsWithChildren<
     update,
     hide,
     show,
+    isOpen,
     showMessages,
     showNewMessages,
     getVisitorId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -315,6 +315,10 @@ export type IntercomContextValues = {
    */
   show: () => void;
   /**
+   * The visibility status of the messenger.
+   */
+  isOpen: boolean;
+  /**
    * Opens the Messenger with the message list.
    */
   showMessages: () => void;


### PR DESCRIPTION
## Context

When you create your custom Intercom launcher, you may want it to change depending of if the messenger is open or closed.

Currently, you can play around `Intercom('show/hide')`, but their implementation is not satisfying as it's just impossible to remove the listeners you attach through these methods (why ? I really don't know...).

## Solution

This PR simply add an `isOpen` flag to `useIntercom()` to solve the problem described above.