### PR TITLE
feat: add isOpen flag to useIntercom() (re-open)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,12 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 
  Make sure `IntercomProvider` is wrapped around your component when calling `useIntercom()`. 
 
-**Remark** - You can't use `useIntercom()` in the same component where `IntercomProvider` is initialized. 
+**Remark** - You can't use `useIntercom()` in the same component where `IntercomProvider` is initialized.
+
+#### State
+| name                | type             | description                                                                             |
+|---------------------|------------------|-----------------------------------------------------------------------------------------|
+| isOpen              | boolean          | the visibility status of the messenger                                                  |
 
 #### Methods
 | name            | type                                       | description                                                                                                                         |

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -75,12 +75,24 @@ export const IntercomProvider: React.FC<React.PropsWithChildren<
     [apiBase, appId, shouldInitialize],
   );
 
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const onHideWrapper = React.useCallback(() => {
+    setIsOpen(false);
+    if (onHide) onHide();
+  }, [onHide, setIsOpen]);
+
+  const onShowWrapper = React.useCallback(() => {
+    setIsOpen(true);
+    if (onShow) onShow();
+  }, [onShow, setIsOpen]);
+
   if (!isSSR && shouldInitialize && !isInitialized.current) {
     initialize(appId, initializeDelay);
 
     // attach listeners
-    if (onHide) IntercomAPI('onHide', onHide);
-    if (onShow) IntercomAPI('onShow', onShow);
+    IntercomAPI('onHide', onHideWrapper);
+    IntercomAPI('onShow', onShowWrapper);
     if (onUnreadCountChange)
       IntercomAPI('onUnreadCountChange', onUnreadCountChange);
 
@@ -231,6 +243,7 @@ export const IntercomProvider: React.FC<React.PropsWithChildren<
       update,
       hide,
       show,
+      isOpen,
       showMessages,
       showNewMessages,
       getVisitorId,
@@ -245,6 +258,7 @@ export const IntercomProvider: React.FC<React.PropsWithChildren<
     update,
     hide,
     show,
+    isOpen,
     showMessages,
     showNewMessages,
     getVisitorId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -315,6 +315,10 @@ export type IntercomContextValues = {
    */
   show: () => void;
   /**
+   * The visibility status of the messenger.
+   */
+  isOpen: boolean;
+  /**
    * Opens the Messenger with the message list.
    */
   showMessages: () => void;


### PR DESCRIPTION
Hi ! I re-open [this PR ](https://github.com/devrnt/react-use-intercom/pull/509) because it seems like my previous explanations were not clear enough.

The problem does not come from this lib side, but from the Intercom side. Let me be more precise: when you register a callback with Intercom('onShow') and Intercom('onHide'), there is absolutely no way to remove it . I mean, this is not implemented in the Intercom object.

So you're correct when you say it's perfectly possible to keep track of the opening status in a local state, attaching listeners in a useEffect hook. The problem is that as you can't remove the added listeners, they will continue to exist even after the unmounting of your component. It's not a big memory leak, but it is one, and it is not wanted for clean stuff.

The only clean solution is to track the opening state at a root level, in a component that will never be unmounted to avoid the memory leak. The cleanest way imo would be to have it in the IntercomContext.

You consider this feature to be out of the scope of this lib, but I totally disagree.
The only other clean alternative (from our product side) would be to wrap the IntercomProvider in an other context prodiver simply adding this isOpen flag. This is something that you don't really want when it could be part of the original lib.

Your lib, your choice obviously. I hope this more detailed explanation of the problem will make you change your mind on this feature.

All the best 👋