### PR TITLE
Change last_requested_at to last_request_at

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -150,8 +150,8 @@ export const IntercomProvider: React.FC<React.PropsWithChildren<
 
   const refresh = React.useCallback(() => {
     ensureIntercom('update', () => {
-      const lastRequestedAt = new Date().getTime();
-      IntercomAPI('update', { last_requested_at: lastRequestedAt });
+      const last_request_at = Math.floor(new Date().getTime() / 1000);
+      IntercomAPI('update', { last_request_at });
     });
   }, [ensureIntercom]);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export type MessengerAttributes = {
 export type RawDataAttributesCompany = {
   company_id: string;
   name?: string;
-  created_at?: string;
+  created_at?: string | number;
   plan?: string;
   monthly_spend?: number;
   user_count?: number;
@@ -77,7 +77,7 @@ export type DataAttributesCompany = {
   /** The name of the company */
   name?: string;
   /** The time the company was created in your system */
-  createdAt?: string;
+  createdAt?: string | number;
   /** The name of the plan the company is on */
   plan?: string;
   /** How much revenue the company generates for your business */
@@ -114,10 +114,10 @@ export type DataAttributesAvatar = {
 export type RawDataAttributes = {
   email?: string;
   user_id?: string;
-  created_at?: string;
+  created_at?: string | number;
   name?: string;
   phone?: string;
-  last_request_at?: string;
+  last_request_at?: string | number;
   unsubscribed_from_emails?: boolean;
   language_override?: string;
   utm_campaign?: string;
@@ -146,8 +146,10 @@ export type DataAttributes = {
   /** The Unix timestamp (in seconds) when the user signed up to your app
    *
    * @remarks Only applicable to users
+   *
+   * @see {@link https://www.intercom.com/help/en/articles/3605703-how-dates-work-in-intercom}
    */
-  createdAt?: string;
+  createdAt?: string | number;
   /** Name of the current user/lead */
   name?: string;
   /** Name of the current user/lead */
@@ -156,7 +158,7 @@ export type DataAttributes = {
    *
    * @remarks It automatically uses the time of the last request but is a this is a reserved attribute
    */
-  lastRequestAt?: string;
+  lastRequestAt?: string | number;
   /** Sets the unsubscribe status of the record
    *
    * @see {@link https://www.intercom.com/help/en/articles/270-how-do-i-unsubscribe-users-from-receiving-emails}


### PR DESCRIPTION
The attribute to do a "page view" update (without user attribute changes) is `last_request_at`, rather than `last_requested_at`. This translates to the default attribute in the Intercom UI "Last Seen" ([source](https://developers.intercom.com/installing-intercom/docs/javascript-api-attributes-objects#mapping-of-javascript-attributes-to-intercom-dashboard-and-api))

Also, the attribute takes seconds rather than milliseconds.

Here's the documentation which talks about doing page view updates: https://www.intercom.com/help/en/articles/170-integrate-intercom-in-a-single-page-app

-----

With the current version of this package, user objects in Intercom have the following invalid attribute:
![Screenshot 2023-01-28 at 18 43 33](https://user-images.githubusercontent.com/544628/215285262-6d93a464-fa39-41d9-8f68-5c3b93f0b91e.png)
