### PR TITLE
feat: add showSpace method

### DIFF
--- a/.changeset/tame-chairs-build.md
+++ b/.changeset/tame-chairs-build.md
@@ -1,0 +1,5 @@
+---
+'react-use-intercom': minor
+---
+
+Add "showSpace" method

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 | trackEvent      | (event: string, metaData?: object) => void | submits an `event` with optional `metaData`      
 | showArticle      | (articleId: string) => void | opens the Messenger with the specified article by `articleId`
 | startSurvey      | (surveyId: number) => void | Trigger a survey in the Messenger by `surveyId`
-| showSpace     | (spaceName: `'home' | 'messages' | 'help' | 'news' | 'tasks'`) => void | Opens the Messenger with the specified space
+| showSpace     | (spaceName: IntercomSpace) => void | Opens the Messenger with the specified space
 
 #### Example
 ```javascript

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 | trackEvent      | (event: string, metaData?: object) => void | submits an `event` with optional `metaData`      
 | showArticle      | (articleId: string) => void | opens the Messenger with the specified article by `articleId`
 | startSurvey      | (surveyId: number) => void | Trigger a survey in the Messenger by `surveyId`
+| showSpace     | (spaceName: `'home' | 'messages' | 'help' | 'news' | 'tasks'`) => void | Opens the Messenger with the specified space
 
 #### Example
 ```javascript
@@ -169,7 +170,8 @@ const HomePage = () => {
     startTour,
     trackEvent,
     showArticle,
-    startSurvey
+    startSurvey,
+    showSpace
   } = useIntercom();
 
   const bootWithProps = () => boot({ name: 'Russo' });
@@ -185,6 +187,7 @@ const HomePage = () => {
     });
   const handleShowArticle = () => showArticle(123456);
   const handleStartSurvey = () => startSurvey(123456);
+  const handleShowSpace = () => showSpace('tasks');
 
   return (
     <>
@@ -209,6 +212,7 @@ const HomePage = () => {
       </button>
       <button onClick={handleShowArticle}>Open article in Messenger</button>
       <button onClick={handleStartSurvey}>Start survey in Messenger</button>
+      <button onClick={handleShowSpace}>Open space in Messenger</button>
     </>
   );
 };

--- a/apps/playground/src/modules/useIntercom/useIntercom.tsx
+++ b/apps/playground/src/modules/useIntercom/useIntercom.tsx
@@ -38,6 +38,7 @@ const RawUseIntercomPage = () => {
     trackEvent,
     showArticle,
     startSurvey,
+    showSpace,
   } = useIntercom();
   const handleBoot = React.useCallback(() => boot(), [boot]);
 
@@ -141,6 +142,10 @@ const RawUseIntercomPage = () => {
   const handleShowArticle = React.useCallback(() => {
     showArticle(4013997);
   }, [showArticle]);
+
+  const handleShowSpace = React.useCallback(() => {
+    showSpace('messages');
+  }, [showSpace]);
 
   const handleStartSurvey = () => startSurvey(29938254);
 
@@ -277,6 +282,12 @@ const RawUseIntercomPage = () => {
           label="Start survey"
           onClick={handleStartSurvey}
         />
+      </Item>
+      <Item>
+        <p>
+          opens a messenger with the given <code>space</code>
+        </p>
+        <Button label="Open space" onClick={handleShowSpace} />
       </Item>
     </Grid>
   );

--- a/apps/playground/src/modules/useIntercom/useIntercom.tsx
+++ b/apps/playground/src/modules/useIntercom/useIntercom.tsx
@@ -285,7 +285,7 @@ const RawUseIntercomPage = () => {
       </Item>
       <Item>
         <p>
-          opens a messenger with the given <code>space</code>
+          opens the Messenger with the given <code>space</code>
         </p>
         <Button label="Open space" onClick={handleShowSpace} />
       </Item>

--- a/packages/react-use-intercom/README.md
+++ b/packages/react-use-intercom/README.md
@@ -140,7 +140,7 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 | trackEvent      | (event: string, metaData?: object) => void | submits an `event` with optional `metaData`      
 | showArticle      | (articleId: string) => void | opens the Messenger with the specified article by `articleId`
 | startSurvey      | (surveyId: number) => void | Trigger a survey in the Messenger by `surveyId`
-| showSpace     | (spaceName: `'home' | 'messages' | 'help' | 'news' | 'tasks'`) => void | Opens the Messenger with the specified space
+| showSpace     | (spaceName: IntercomSpace) => void | Opens the Messenger with the specified space
 
 #### Example
 ```javascript

--- a/packages/react-use-intercom/README.md
+++ b/packages/react-use-intercom/README.md
@@ -140,6 +140,7 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 | trackEvent      | (event: string, metaData?: object) => void | submits an `event` with optional `metaData`      
 | showArticle      | (articleId: string) => void | opens the Messenger with the specified article by `articleId`
 | startSurvey      | (surveyId: number) => void | Trigger a survey in the Messenger by `surveyId`
+| showSpace     | (spaceName: `'home' | 'messages' | 'help' | 'news' | 'tasks'`) => void | Opens the Messenger with the specified space
 
 #### Example
 ```javascript
@@ -169,7 +170,8 @@ const HomePage = () => {
     startTour,
     trackEvent,
     showArticle,
-    startSurvey
+    startSurvey,
+    showSpace
   } = useIntercom();
 
   const bootWithProps = () => boot({ name: 'Russo' });
@@ -185,6 +187,7 @@ const HomePage = () => {
     });
   const handleShowArticle = () => showArticle(123456);
   const handleStartSurvey = () => startSurvey(123456);
+  const handleShowSpace = () => showSpace('tasks');
 
   return (
     <>
@@ -209,6 +212,7 @@ const HomePage = () => {
       </button>
       <button onClick={handleShowArticle}>Open article in Messenger</button>
       <button onClick={handleStartSurvey}>Start survey in Messenger</button>
+      <button onClick={handleShowSpace}>Open space in Messenger</button>
     </>
   );
 };

--- a/packages/react-use-intercom/src/provider.tsx
+++ b/packages/react-use-intercom/src/provider.tsx
@@ -9,6 +9,7 @@ import {
   IntercomContextValues,
   IntercomProps,
   IntercomProviderProps,
+  IntercomSpace,
   RawIntercomBootProps,
 } from './types';
 import { isSSR } from './utils';
@@ -229,6 +230,14 @@ export const IntercomProvider: React.FC<
     [ensureIntercom],
   );
 
+  const showSpace = React.useCallback(
+    (spaceName: IntercomSpace) =>
+      ensureIntercom('showSpace', () => {
+        IntercomAPI('showSpace', spaceName);
+      }),
+    [ensureIntercom],
+  );
+
   const startSurvey = React.useCallback(
     (surveyId: number) => {
       ensureIntercom('startSurvey', () => {
@@ -254,6 +263,7 @@ export const IntercomProvider: React.FC<
       trackEvent,
       showArticle,
       startSurvey,
+      showSpace,
     };
   }, [
     boot,
@@ -270,6 +280,7 @@ export const IntercomProvider: React.FC<
     trackEvent,
     showArticle,
     startSurvey,
+    showSpace,
   ]);
 
   return (

--- a/packages/react-use-intercom/src/types.ts
+++ b/packages/react-use-intercom/src/types.ts
@@ -244,7 +244,8 @@ export type IntercomMethod =
   | 'trackEvent'
   | 'getVisitorId'
   | 'startTour'
-  | 'showArticle';
+  | 'showArticle'
+  | 'showSpace';
 
 export type RawIntercomProps = RawMessengerAttributes & RawDataAttributes;
 
@@ -261,6 +262,8 @@ export type IntercomBootProps = {
 } & IntercomProps;
 
 export type LogLevel = 'info' | 'error' | 'warn';
+
+export type IntercomSpace = 'home' | 'messages' | 'help' | 'news' | 'tasks';
 
 export type IntercomContextValues = {
   /**
@@ -404,6 +407,17 @@ export type IntercomContextValues = {
    * @param surveyId The id of the survey
    */
   startSurvey: (surveyId: number) => void;
+  /**
+   *
+   * @see {@link https://developers.intercom.com/installing-intercom/docs/intercom-javascript#intercomshowspace-spacename}
+   *
+   * @remarks if a space with the given name doesn't exist, you will see a type error
+   *
+   * @param spaceName The name of the space
+   *
+   * @example showSpace('tasks')
+   */
+  showSpace: (spaceName: IntercomSpace) => void;
 };
 
 export type IntercomProviderProps = {


### PR DESCRIPTION
# Description

Added [showSpace](https://developers.intercom.com/installing-intercom/docs/intercom-javascript#intercomshowspace-spacename) method to open the Messenger with the specified space. The functionality of spaces is pretty fresh in the Intercom API, so I'm not sure if this is the best way to do it. I'm happy to change it if there's a better way.