### PR TITLE
Use lower node version (14)

### DIFF
--- a/packages/react-use-intercom/package.json
+++ b/packages/react-use-intercom/package.json
@@ -21,7 +21,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=14"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Fix #638 Use lower node version to prevent npm claims about node < 18

npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'react-use-intercom@5.0.0',
npm WARN EBADENGINE   required: { node: '>=18' },
npm WARN EBADENGINE   current: { node: 'v16.19.1', npm: '8.19.3' }
npm WARN EBADENGINE }