### PR TITLE
Apply `use client` directive to `IntercomProvider`

### DIFF
--- a/packages/react-use-intercom/src/provider.tsx
+++ b/packages/react-use-intercom/src/provider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from 'react';
 
 import IntercomAPI from './api';


### PR DESCRIPTION
The App Router in NextJS 13 requires Providers used in server components to have the `use client` directive. 

This means that using IntercomProvider in a Root Layout (which must be an SRC) requires wrapping it in a client-side component. 

This PR declares the provider as a client component.

See: https://nextjs.org/docs/getting-started/react-essentials#rendering-third-party-context-providers-in-server-components