### PR TITLE
Add support for `zIndex` property 

### DIFF
--- a/.changeset/khaki-sloths-heal.md
+++ b/.changeset/khaki-sloths-heal.md
@@ -1,0 +1,5 @@
+---
+'react-use-intercom': patch
+---
+
+Add support for zIndex launcher property

--- a/packages/react-use-intercom/src/mappers.ts
+++ b/packages/react-use-intercom/src/mappers.ts
@@ -19,6 +19,7 @@ export const mapMessengerAttributesToRawMessengerAttributes = (
   alignment: attributes.alignment,
   vertical_padding: attributes.verticalPadding,
   horizontal_padding: attributes.horizontalPadding,
+  z_index: attributes.zIndex,
   hide_default_launcher: attributes.hideDefaultLauncher,
   session_duration: attributes.sessionDuration,
   action_color: attributes.actionColor,

--- a/packages/react-use-intercom/src/types.ts
+++ b/packages/react-use-intercom/src/types.ts
@@ -3,6 +3,7 @@ export type RawMessengerAttributes = {
   alignment?: string;
   vertical_padding?: number;
   horizontal_padding?: number;
+  z_index?: number;
   hide_default_launcher?: boolean;
   session_duration?: number;
   action_color?: string;
@@ -34,6 +35,11 @@ export type MessengerAttributes = {
    * @see {@link https://docs.intercom.com/configure-intercom-for-your-product-or-site/customize-the-intercom-messenger/customize-the-intercom-messenger-technical}
    */
   horizontalPadding?: number;
+  /** Set the z-index of the messenger
+   * @remarks The z-index of the messenger. Default value: 2147483001
+   * @see {@link https://developers.intercom.com/installing-intercom/web/customization}
+   * */
+  zIndex?: number;
   /** Hide the default launcher icon
    *
    * @remarks Setting to false will forcefully show the launcher icon


### PR DESCRIPTION
There's currently no way to pass the `z_index` property to Intercom. This just adds it into the mapping alongside horizontalPadding and similar, to be used like this:

```
<IntercomProvider
   autoBootProps={{zIndex: 1000}}
/>
```