### PR TITLE
Write nonce to <script> tag with setAttribute()

### DIFF
--- a/.changeset/gentle-melons-look.md
+++ b/.changeset/gentle-melons-look.md
@@ -1,0 +1,5 @@
+---
+'react-use-intercom': patch
+---
+
+Repair nonces on <script> tags

--- a/packages/react-use-intercom/src/initialize.ts
+++ b/packages/react-use-intercom/src/initialize.ts
@@ -32,7 +32,7 @@ const initialize = (appId: string, timeout: number = 0, cspNonce?: string) => {
         var s = d.createElement('script');
         s.type = 'text/javascript';
         s.async = true;
-        if (cspNonce) s.nonce = cspNonce;
+        if (cspNonce) s.setAttribute('nonce', cspNonce);
         s.src = 'https://widget.intercom.io/widget/' + appId;
         var x = d.getElementsByTagName('script')[0];
         x.parentNode.insertBefore(s, x);


### PR DESCRIPTION
Sets nonce on &lt;script&gt; tag thru setAttribute() instead of HTMLScriptElement.nonce property.

HTMLScriptElement.nonce doesn’t work in all browsers – setAttribute() does.

```
const script = document.createElement('script');
script.type = 'text/javascript';

script.nonce = 'abc';
script.outerHTML; // '<script type="text/javascript"></script>'

script.setAttribute('nonce', 'abc');
script.outerHTML; // '<script type="text/javascript" nonce="abc"></script>'
```