### PR TITLE
Add hideNotifications method and tickets space support

### DIFF
--- a/.changeset/quick-bells-hide.md
+++ b/.changeset/quick-bells-hide.md
@@ -1,0 +1,5 @@
+---
+'react-use-intercom': minor
+---
+
+Add `hideNotifications` method and support for the `tickets` space in `showSpace`

--- a/packages/react-use-intercom/README.md
+++ b/packages/react-use-intercom/README.md
@@ -152,7 +152,7 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 | showNews | (newsId: number) => void | Opens the Messenger with the specified news item by `newsId`
 | showTicket | (ticketId: number) => void | Opens the Messenger with the specified ticket by `ticketId`
 | showConversation | (conversationId: number) => void | Opens the Messenger with the specified conversation by `conversationId`
-| hideNotifications | (hidden: boolean) => void | Controls the visibility of Intercom notifications
+| hideNotifications | (hidden: boolean) => void | controls the visibility of in-app notifications, pass `true` to hide or `false` to show them
 
 #### Example
 ```ts

--- a/packages/react-use-intercom/README.md
+++ b/packages/react-use-intercom/README.md
@@ -149,8 +149,10 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 | showArticle      | (articleId: string) => void | opens the Messenger with the specified article by `articleId`
 | startSurvey      | (surveyId: number) => void | Trigger a survey in the Messenger by `surveyId`
 | showSpace     | (spaceName: IntercomSpace) => void | Opens the Messenger with the specified space
+| showNews | (newsId: number) => void | Opens the Messenger with the specified news item by `newsId`
 | showTicket | (ticketId: number) => void | Opens the Messenger with the specified ticket by `ticketId`
 | showConversation | (conversationId: number) => void | Opens the Messenger with the specified conversation by `conversationId`
+| hideNotifications | (hidden: boolean) => void | Controls the visibility of Intercom notifications
 
 #### Example
 ```ts
@@ -183,8 +185,10 @@ const HomePage = () => {
     showArticle,
     startSurvey,
     showSpace,
+    showNews,
     showTicket,
-    showConversation
+    showConversation,
+    hideNotifications,
   } = useIntercom();
 
   const bootWithProps = () => boot({ name: 'Russo' });
@@ -202,8 +206,10 @@ const HomePage = () => {
   const handleShowArticle = () => showArticle(123456);
   const handleStartSurvey = () => startSurvey(123456);
   const handleShowSpace = () => showSpace('tasks');
+  const handleShowNews = () => showNews(123);
   const handleShowTicket = () => showTicket(123);
   const handleShowConversation = () => showConversation(123);
+  const handleHideNotifications = () => hideNotifications(true);
 
   return (
     <>
@@ -230,8 +236,10 @@ const HomePage = () => {
       <button onClick={handleShowArticle}>Open article in Messenger</button>
       <button onClick={handleStartSurvey}>Start survey in Messenger</button>
       <button onClick={handleShowSpace}>Open space in Messenger</button>
+      <button onClick={handleShowNews}>Open news in Messenger</button>
       <button onClick={handleShowTicket}>Open ticket in Messenger</button>
       <button onClick={handleShowConversation}>Open conversation in Messenger</button>
+      <button onClick={handleHideNotifications}>Hide notifications</button>
     </>
   );
 };

--- a/packages/react-use-intercom/src/provider.tsx
+++ b/packages/react-use-intercom/src/provider.tsx
@@ -291,6 +291,15 @@ export const IntercomProvider: React.FC<
     [ensureIntercom],
   );
 
+  const hideNotifications = React.useCallback(
+    (hidden: boolean) => {
+      ensureIntercom('hideNotifications', () => {
+        IntercomAPI('hideNotifications', hidden);
+      });
+    },
+    [ensureIntercom],
+  );
+
   const providerValue = React.useMemo<IntercomContextValues>(() => {
     return {
       boot,
@@ -312,6 +321,7 @@ export const IntercomProvider: React.FC<
       showNews,
       showTicket,
       showConversation,
+      hideNotifications,
     };
   }, [
     boot,
@@ -333,6 +343,7 @@ export const IntercomProvider: React.FC<
     showNews,
     showTicket,
     showConversation,
+    hideNotifications,
   ]);
 
   return (

--- a/packages/react-use-intercom/src/types.ts
+++ b/packages/react-use-intercom/src/types.ts
@@ -262,7 +262,8 @@ export type IntercomMethod =
   | 'showSpace'
   | 'showNews'
   | 'showTicket'
-  | 'showConversation';
+  | 'showConversation'
+  | 'hideNotifications';
 
 export type RawIntercomProps = RawMessengerAttributes & RawDataAttributes;
 
@@ -280,7 +281,7 @@ export type IntercomBootProps = {
 
 export type LogLevel = 'info' | 'error' | 'warn';
 
-export type IntercomSpace = 'home' | 'messages' | 'help' | 'news' | 'tasks';
+export type IntercomSpace = 'home' | 'messages' | 'help' | 'news' | 'tasks' | 'tickets';
 
 export type IntercomContextValues = {
   /**
@@ -476,6 +477,14 @@ export type IntercomContextValues = {
    * @see {@link https://developers.intercom.com/installing-intercom/web/methods/#intercomshowconversation-conversationid}
    */
   showConversation: (conversationId: number) => void;
+  /**
+   * Controls the visibility of Intercom notifications
+   *
+   * @see {@link https://developers.intercom.com/installing-intercom/web/methods/#intercomhidenotifications-hidden}
+   *
+   * @param hidden `true` to hide notifications, `false` to show them
+   */
+  hideNotifications: (hidden: boolean) => void;
 };
 
 export type IntercomProviderProps = {


### PR DESCRIPTION
Add the missing `hideNotifications` JS SDK method and add `tickets` to the `IntercomSpace` type. Update README with docs for both additions and the previously undocumented `showNews` method.