### PR TITLE
Add startConversation method and missing Messenger/data attributes.

### DIFF
--- a/.changeset/wise-mangos-hunt.md
+++ b/.changeset/wise-mangos-hunt.md
@@ -1,0 +1,5 @@
+---
+'react-use-intercom': minor
+---
+
+Add the `startConversation` method and support for the `linkColor`, `themeMode`, `messengerStyleId`, `hideNotifications` and `pageTitle` attributes

--- a/packages/react-use-intercom/README.md
+++ b/packages/react-use-intercom/README.md
@@ -142,6 +142,7 @@ Used to retrieve all methods bundled with Intercom. These are based on the offic
 | show            | () => void                                 | shows the Messenger, will call `onShow` if supplied to `IntercomProvider`                                                           |
 | showMessages    | () => void                                 | shows the Messenger with the message list                                                                                           |
 | showNewMessage  | (content?: string) => void                 | shows the Messenger as if a new conversation was just created. If `content` is passed, it will fill in the message composer         |
+| startConversation | (message: string) => void                | opens the Messenger and immediately starts a new conversation with the supplied `message`                                          |
 | getVisitorId    | () => string                               | gets the visitor id                                                                                                                 |
 | startTour       | (tourId: number) => void                   | starts a tour based on the `tourId`                                                                                                 |
 | startChecklist       | (checklistId: number) => void                   | starts a checklist based on the `checklistId`                                                                                                 |
@@ -178,6 +179,7 @@ const HomePage = () => {
     show,
     showMessages,
     showNewMessage,
+    startConversation,
     getVisitorId,
     startTour,
     startChecklist,
@@ -195,6 +197,7 @@ const HomePage = () => {
   const updateWithProps = () => update({ name: 'Ossur' });
   const handleNewMessages = () => showNewMessage();
   const handleNewMessagesWithContent = () => showNewMessage('content');
+  const handleStartConversation = () => startConversation('Hello');
   const handleGetVisitorId = () => console.log(getVisitorId());
   const handleStartTour = () => startTour(123);
   const handleStartChecklist = () => startChecklist(456);
@@ -226,6 +229,7 @@ const HomePage = () => {
       <button onClick={handleNewMessagesWithContent}>
         Show new message with pre-filled content
       </button>
+      <button onClick={handleStartConversation}>Start conversation</button>
       <button onClick={handleGetVisitorId}>Get visitor id</button>
       <button onClick={handleStartTour}>Start tour</button>
       <button onClick={handleStartChecklist}>Start checklist</button>

--- a/packages/react-use-intercom/src/mappers.ts
+++ b/packages/react-use-intercom/src/mappers.ts
@@ -24,6 +24,10 @@ export const mapMessengerAttributesToRawMessengerAttributes = (
   session_duration: attributes.sessionDuration,
   action_color: attributes.actionColor,
   background_color: attributes.backgroundColor,
+  link_color: attributes.linkColor,
+  theme_mode: attributes.themeMode,
+  messenger_style_id: attributes.messengerStyleId,
+  hide_notifications: attributes.hideNotifications,
 });
 
 const mapDataAttributesCompanyToRawDataAttributesCompany = (
@@ -75,6 +79,7 @@ export const mapDataAttributesToRawDataAttributes = (
     mapDataAttributesCompanyToRawDataAttributesCompany,
   ),
   intercom_user_jwt: attributes.intercomUserJwt,
+  page_title: attributes.pageTitle,
   ...attributes.customAttributes,
 });
 

--- a/packages/react-use-intercom/src/provider.tsx
+++ b/packages/react-use-intercom/src/provider.tsx
@@ -300,6 +300,15 @@ export const IntercomProvider: React.FC<
     [ensureIntercom],
   );
 
+  const startConversation = React.useCallback(
+    (message: string) => {
+      ensureIntercom('startConversation', () => {
+        IntercomAPI('startConversation', message);
+      });
+    },
+    [ensureIntercom],
+  );
+
   const providerValue = React.useMemo<IntercomContextValues>(() => {
     return {
       boot,
@@ -311,6 +320,7 @@ export const IntercomProvider: React.FC<
       isOpen,
       showMessages,
       showNewMessage,
+      startConversation,
       getVisitorId,
       startTour,
       startChecklist,
@@ -333,6 +343,7 @@ export const IntercomProvider: React.FC<
     isOpen,
     showMessages,
     showNewMessage,
+    startConversation,
     getVisitorId,
     startTour,
     startChecklist,

--- a/packages/react-use-intercom/src/types.ts
+++ b/packages/react-use-intercom/src/types.ts
@@ -8,6 +8,10 @@ export type RawMessengerAttributes = {
   session_duration?: number;
   action_color?: string;
   background_color?: string;
+  link_color?: string;
+  theme_mode?: string;
+  messenger_style_id?: string;
+  hide_notifications?: boolean;
 };
 
 export type MessengerAttributes = {
@@ -63,6 +67,30 @@ export type MessengerAttributes = {
    * @see {@link https://www.w3schools.com/cssref/css_colors.asp}
    */
   backgroundColor?: string;
+  /** Used for the color of links in the messenger
+   *
+   * @remarks The color string can be any valid CSS: "color name", "hex" or "rgb"
+   * @see {@link https://www.w3schools.com/cssref/css_colors.asp}
+   */
+  linkColor?: string;
+  /** Set the color mode of the messenger
+   *
+   * @remarks Possible values: "light", "dark" or "system"
+   * @see {@link https://developers.intercom.com/installing-intercom/web/attributes-objects}
+   */
+  themeMode?: 'light' | 'dark' | 'system';
+  /** Load a specific messenger style configuration by its id
+   *
+   * @remarks Useful when you have multiple messenger styles configured for your workspace
+   * @see {@link https://developers.intercom.com/installing-intercom/web/attributes-objects}
+   */
+  messengerStyleId?: string;
+  /** Hide the in-app notifications when the messenger is booted
+   *
+   * @remarks To toggle notifications at runtime after boot, use the `hideNotifications` method instead
+   * @see {@link https://developers.intercom.com/installing-intercom/web/attributes-objects}
+   */
+  hideNotifications?: boolean;
 };
 
 export type RawDataAttributesCompany = {
@@ -136,6 +164,7 @@ export type RawDataAttributes = {
   company?: RawDataAttributesCompany;
   companies?: RawDataAttributesCompany[];
   intercom_user_jwt?: string;
+  page_title?: string;
   customAttributes?: Record<string, any>;
 };
 
@@ -225,6 +254,12 @@ export type DataAttributes = {
    */
   intercomUserJwt?: string;
   /**
+   * The title of the current page, used to track page views
+   *
+   * @see {@link https://developers.intercom.com/installing-intercom/web/attributes-objects}
+   */
+  pageTitle?: string;
+  /**
    * You can do this anytime by adding additional key/value pairs to your intercomSettings code snippet
    * These should be raw snake_cased
    *
@@ -249,6 +284,7 @@ export type IntercomMethod =
   | 'show'
   | 'showMessages'
   | 'showNewMessage'
+  | 'startConversation'
   | 'startSurvey'
   | 'onHide'
   | 'onShow'
@@ -364,6 +400,15 @@ export type IntercomContextValues = {
    * ```
    */
   showNewMessage: (prePopulatedContent?: string) => void;
+  /**
+   * Opens the Messenger and immediately starts a new conversation by sending the
+   * supplied message on behalf of the current user.
+   *
+   * @see {@link https://developers.intercom.com/installing-intercom/web/methods/#intercomstartconversation-message}
+   *
+   * @param message The message to send to start the conversation
+   */
+  startConversation: (message: string) => void;
   /**
    * A visitor is someone who goes to your site but does not use the messenger.
    * You can track these visitors via the visitor `user_id`.


### PR DESCRIPTION
## What

Closes the remaining gaps between `react-use-intercom` and the official [Intercom JavaScript SDK](https://developers.intercom.com/installing-intercom/web/methods), found
 by a full scan of the [methods](https://developers.intercom.com/installing-intercom/web/methods) and [attributes/objects](https://developers.intercom.com/installing-int
ercom/web/attributes-objects) docs.

### Method
- **`startConversation(message)`** — opens the Messenger and immediately starts a new conversation with the supplied message.

### Messenger attributes
- **`linkColor`** (`link_color`) — hyperlink color in messages.
- **`themeMode`** (`theme_mode`) — `'light' | 'dark' | 'system'`.
- **`messengerStyleId`** (`messenger_style_id`) — load a specific messenger style configuration.
- **`hideNotifications`** (`hide_notifications`) — start with in-app notifications hidden at boot (pairs with the existing `hideNotifications` runtime method).

### Data attribute
- **`pageTitle`** (`page_title`) — page-view tracking label.

## Notes
- All additions are optional and backwards-compatible → `minor` (changeset included).
- Attributes follow the existing camelCase → snake_case mapping in `mappers.ts`; README continues to defer attribute docs to the `IntercomProps` types.

## Verification
- `pnpm build` (incl. DTS typecheck) ✓
- `pnpm test` ✓
- `pnpm lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)