### PR TITLE
Add crossOrigin, onLoad and onLoadFailed options to IntercomProvider

### DIFF
--- a/.changeset/tidy-otters-jam.md
+++ b/.changeset/tidy-otters-jam.md
@@ -1,0 +1,5 @@
+---
+'react-use-intercom': minor
+---
+
+Add `crossOrigin`, `onLoad` and `onLoadFailed` options to `IntercomProvider` to set the messenger `<script>` crossorigin attribute and detect when the messenger script loads or fails to load

--- a/apps/playground/cypress/e2e/crossOrigin.ts
+++ b/apps/playground/cypress/e2e/crossOrigin.ts
@@ -1,0 +1,13 @@
+/// <reference types="cypress" />
+
+describe('crossOrigin', () => {
+  it('should set the crossorigin attribute on the Messenger script tag', () => {
+    cy.visit('/useIntercomWithCrossOrigin');
+
+    cy.get('head script[src*="widget.intercom.io"]').should(
+      'have.attr',
+      'crossorigin',
+      'anonymous',
+    );
+  });
+});

--- a/apps/playground/cypress/e2e/loadCallbacks.ts
+++ b/apps/playground/cypress/e2e/loadCallbacks.ts
@@ -1,0 +1,26 @@
+/// <reference types="cypress" />
+
+describe('onLoad / onLoadFailed', () => {
+  it('should call onLoad when the Messenger script loads successfully', () => {
+    // Bypass the cache so the script is actually (re)requested on each run
+    cy.intercept('https://widget.intercom.io/widget/jcabc7e3', (req) => {
+      req.continue((res) => {
+        res.headers['cache-control'] = 'no-cache';
+      });
+    });
+
+    cy.visit('/useIntercomWithLoadCallbacks');
+
+    cy.get('[data-cy=call]').should('have.text', 'onLoad was called!');
+  });
+
+  it('should call onLoadFailed when the Messenger script fails to load', () => {
+    cy.intercept('https://widget.intercom.io/widget/jcabc7e3', {
+      forceNetworkError: true,
+    });
+
+    cy.visit('/useIntercomWithLoadCallbacks');
+
+    cy.get('[data-cy=call]').should('have.text', 'onLoadFailed was called!');
+  });
+});

--- a/apps/playground/src/app.tsx
+++ b/apps/playground/src/app.tsx
@@ -9,7 +9,9 @@ import {
   ProviderPage,
   UseIntercomPage,
   UseIntercomTourPage,
+  UseIntercomWithCrossOrigin,
   UseIntercomWithDelay,
+  UseIntercomWithLoadCallbacks,
 } from './modules';
 import { Page, Style } from './modules/common';
 
@@ -53,8 +55,16 @@ const App = () => {
           <Route path="/useIntercom" component={UseIntercomPage} />
           <Route path="/useIntercomTour" component={UseIntercomTourPage} />
           <Route
+            path="/useIntercomWithCrossOrigin"
+            component={UseIntercomWithCrossOrigin}
+          />
+          <Route
             path="/useIntercomWithTimeout"
             component={UseIntercomWithDelay}
+          />
+          <Route
+            path="/useIntercomWithLoadCallbacks"
+            component={UseIntercomWithLoadCallbacks}
           />
           <Route path="/" exact>
             <Navigation>
@@ -70,8 +80,14 @@ const App = () => {
               <Link to="/useIntercomTour">
                 <code>useIntercom with tour</code>
               </Link>
+              <Link to="/useIntercomWithCrossOrigin">
+                <code>useIntercom with crossOrigin</code>
+              </Link>
               <Link to="/useIntercomWithTimeout">
                 <code>useIntercom with delayed boot</code>
+              </Link>
+              <Link to="/useIntercomWithLoadCallbacks">
+                <code>useIntercom with load callbacks</code>
               </Link>
             </Navigation>
           </Route>

--- a/apps/playground/src/modules/useIntercom/index.ts
+++ b/apps/playground/src/modules/useIntercom/index.ts
@@ -1,3 +1,5 @@
 export { default as UseIntercomPage } from './useIntercom';
 export { default as UseIntercomTourPage } from './useIntercomTour';
+export { default as UseIntercomWithCrossOrigin } from './useIntercomWithCrossOrigin';
 export { default as UseIntercomWithDelay } from './useIntercomWithDelay';
+export { default as UseIntercomWithLoadCallbacks } from './useIntercomWithLoadCallbacks';

--- a/apps/playground/src/modules/useIntercom/useIntercomWithCrossOrigin.tsx
+++ b/apps/playground/src/modules/useIntercom/useIntercomWithCrossOrigin.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { IntercomProvider } from 'react-use-intercom';
+import styled from 'styled-components';
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  width: 100%;
+`;
+
+const Item = styled.div`
+  display: grid;
+  grid-template-rows: min-content;
+
+  &::after {
+    content: '';
+    margin: 2rem 0 1.5rem;
+    border-bottom: 2px solid var(--grey);
+    width: 100%;
+  }
+`;
+
+const RawUseIntercomPage = () => {
+  return (
+    <Grid>
+      <Item>
+        <p>
+          Intercom will be initialized with{' '}
+          <code>crossOrigin: "anonymous"</code> (and autobooted)
+        </p>
+      </Item>
+    </Grid>
+  );
+};
+
+const UseIntercomWithCrossOriginPage = () => {
+  return (
+    <IntercomProvider appId="jcabc7e3" autoBoot crossOrigin="anonymous">
+      <RawUseIntercomPage />
+    </IntercomProvider>
+  );
+};
+
+export default UseIntercomWithCrossOriginPage;

--- a/apps/playground/src/modules/useIntercom/useIntercomWithLoadCallbacks.tsx
+++ b/apps/playground/src/modules/useIntercom/useIntercomWithLoadCallbacks.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { IntercomProvider } from 'react-use-intercom';
+import styled from 'styled-components';
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  width: 100%;
+`;
+
+const Item = styled.div`
+  display: grid;
+  grid-template-rows: min-content;
+
+  &::after {
+    content: '';
+    margin: 2rem 0 1.5rem;
+    border-bottom: 2px solid var(--grey);
+    width: 100%;
+  }
+`;
+
+const RawUseIntercomPage = ({ call }: { call: string | undefined }) => {
+  return (
+    <Grid>
+      <Item>
+        <p>
+          The Intercom Messenger script will be loaded and{' '}
+          <code>onLoad/onLoadFailed</code> be called
+        </p>
+        <p data-cy="call">{call ?? 'Waiting…'}</p>
+      </Item>
+    </Grid>
+  );
+};
+
+const UseIntercomWithLoadCallbacks = () => {
+  const [call, setCall] = React.useState<string>();
+
+  return (
+    <IntercomProvider
+      appId="jcabc7e3"
+      autoBoot
+      onLoad={() => setCall('onLoad was called!')}
+      onLoadFailed={() => setCall('onLoadFailed was called!')}
+    >
+      <RawUseIntercomPage call={call} />
+    </IntercomProvider>
+  );
+};
+
+export default UseIntercomWithLoadCallbacks;

--- a/packages/react-use-intercom/README.md
+++ b/packages/react-use-intercom/README.md
@@ -91,6 +91,9 @@ Place the `IntercomProvider` as high as possible in your application. This will 
 | apiBase    | string | If you need to route your Messenger requests through a different endpoint than the default. Generally speaking, this is not needed.<br/> Format: `https://${INTERCOM_APP_ID}.intercom-messenger.com` (See: [https://github.com/devrnt/react-use-intercom/pull/96](https://github.com/devrnt/react-use-intercom/pull/96))         | false    |         |
 | initializeDelay | number | Indicates if the intercom initialization should be delayed, delay is in ms, defaults to 0. See https://github.com/devrnt/react-use-intercom/pull/236 | false    |         |
 | autoBootProps | IntercomProps | Pass properties to `boot` method when `autoBoot` is `true` | false    |         |
+| crossOrigin | 'anonymous' \| 'use-credentials' \| '' | Sets the [`crossOrigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#crossorigin) attribute on the Messenger `<script>` (standard DOM attribute, not an Intercom API). Use `'anonymous'` for full error details in error logging; works because Intercom's CDN allows CORS | false    |         |
+| onLoad | () => void | triggered when the Messenger script has loaded successfully | false    |         |
+| onLoadFailed | () => void | triggered when the Messenger script has failed to load (network issues, Intercom downtime, firewall, blocking browser extensions, ...) | false    |         |
 
 #### Example
 ```ts
@@ -305,6 +308,24 @@ These props are `JavaScript` 'friendly', so [camelCase](https://en.wikipedia.org
 Since [v1.2.0](https://github.com/devrnt/react-use-intercom/releases/tag/v1.2.0) it's possible to delay this initialisation by passing `initializeDelay` in `<IntercomProvider />` (it's in milliseconds). However most of the users won't need to mess with this.
 
 For reference see https://github.com/devrnt/react-use-intercom/pull/236 and https://forum.intercom.com/s/question/0D52G00004WxWLs/can-i-delay-loading-intercom-on-my-site-to-reduce-the-js-load
+
+### Detect a broken Messenger
+
+The Messenger script can fail to load for various reasons, e.g. network issues, Intercom downtime, firewall rules, or browser extensions like tracking blockers.
+
+Pass `onLoadFailed` to `<IntercomProvider />` to detect when that happens and offer the user an alternative support channel. Use `onLoad` to know when the script loaded successfully (e.g. to hide a loading state).
+
+```tsx
+<IntercomProvider
+  appId={INTERCOM_APP_ID}
+  onLoad={() => console.log('Messenger loaded')}
+  onLoadFailed={() => console.log('Messenger failed to load')}
+>
+  ...
+</IntercomProvider>
+```
+
+Pass `crossOrigin="anonymous"` to unlock full error details for errors thrown by the Messenger loader script — a standard [`<script>` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#crossorigin) rather than an Intercom feature. It works because Intercom's CDN serves the script with permissive CORS headers.
 
 ## Contributing
 

--- a/packages/react-use-intercom/src/initialize.ts
+++ b/packages/react-use-intercom/src/initialize.ts
@@ -8,10 +8,20 @@
  * @param appId - Intercom app id
  * @param [timeout=0] - Amount of milliseconds that the initialization should be delayed, defaults to 0
  * @param [cspNonce=undefined] - Content-Security-Policy nonce to use for the Intercom <script> tag during initializing
+ * @param [crossOrigin=undefined] - `crossOrigin` attribute to set on the Intercom <script> tag
+ * @param [onLoad=undefined] - Called when the Intercom <script> tag has loaded successfully
+ * @param [onLoadFailed=undefined] - Called when the Intercom <script> tag has failed to load
  *
  * @see {@link https://developers.intercom.com/installing-intercom/docs/basic-javascript}
  */
-const initialize = (appId: string, timeout: number = 0, cspNonce?: string) => {
+const initialize = (
+  appId: string,
+  timeout: number = 0,
+  cspNonce?: string,
+  crossOrigin?: string,
+  onLoad?: () => void,
+  onLoadFailed?: () => void,
+) => {
   var w = window;
   var ic = w.Intercom;
   if (typeof ic === 'function') {
@@ -33,7 +43,10 @@ const initialize = (appId: string, timeout: number = 0, cspNonce?: string) => {
         s.type = 'text/javascript';
         s.async = true;
         if (cspNonce) s.setAttribute('nonce', cspNonce);
+        if (crossOrigin) s.crossOrigin = crossOrigin;
         s.src = 'https://widget.intercom.io/widget/' + appId;
+        if (onLoad) s.addEventListener('load', onLoad);
+        if (onLoadFailed) s.addEventListener('error', onLoadFailed);
         var x = d.getElementsByTagName('script')[0];
         x.parentNode.insertBefore(s, x);
       }, timeout);

--- a/packages/react-use-intercom/src/provider.tsx
+++ b/packages/react-use-intercom/src/provider.tsx
@@ -21,7 +21,10 @@ export const IntercomProvider: React.FC<
   autoBoot = false,
   autoBootProps,
   children,
+  crossOrigin,
   onHide,
+  onLoad,
+  onLoadFailed,
   onShow,
   onUnreadCountChange,
   onUserEmailSupplied,
@@ -103,7 +106,14 @@ export const IntercomProvider: React.FC<
   );
 
   if (!isSSR && shouldInitialize && !isInitialized.current) {
-    initialize(appId, initializeDelay, cspNonce);
+    initialize(
+      appId,
+      initializeDelay,
+      cspNonce,
+      crossOrigin,
+      onLoad,
+      onLoadFailed,
+    );
 
     if (autoBoot) {
       boot(autoBootProps);

--- a/packages/react-use-intercom/src/types.ts
+++ b/packages/react-use-intercom/src/types.ts
@@ -586,4 +586,26 @@ export type IntercomProviderProps = {
    * Content-Security-Policy nonce to use for the Intercom <script> tag during initializing
    */
   cspNonce?: string;
+  /**
+   * The `crossOrigin` attribute to set on the `<script>` tag that loads the Messenger.
+   *
+   * @remarks Not part of the Intercom API. Set `'anonymous'` to get full error details for errors
+   * thrown by the loader script — this works because Intercom's CDN serves it with permissive CORS
+   * headers.
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#crossorigin}
+   */
+  crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
+  /**
+   * Called when the Messenger script has loaded successfully.
+   *
+   * @remarks This fires once the loader script has downloaded, not when the Messenger is fully booted.
+   */
+  onLoad?: () => void;
+  /**
+   * Called when the Messenger script has failed to load.
+   *
+   * @remarks Use this to detect a broken Messenger (network issues, Intercom downtime, firewall, or
+   * blocking browser extensions) and offer the user an alternative support channel.
+   */
+  onLoadFailed?: () => void;
 };


### PR DESCRIPTION
Adds three IntercomProvider options:

- crossOrigin — sets the crossorigin attribute on the Messenger <script> (opt-in). Enables full error detail for error logging.
- onLoad / onLoadFailed — detect when the Messenger script loads or fails to load, for a loading state or a fallback support channel when the Messenger is blocked.

Supersedes #675

Continues @fluidsonic's work in #675, preserving authorship via Co-Authored-By. We couldn't push onto that branch: it lives on an organization-owned fork where GitHub doesn't offer "Allow edits by maintainers" (maintainerCanModify is false), so the required rebase couldn't be applied there. Recreated on a maintainer-owned branch, rebased onto current main and reconciled with the newer cspNonce argument in initialize(). Please close #675 in favour of this PR.

Notes

- crossOrigin is a standard <script> attribute, not an Intercom API — verified Intercom's CDN serves the script with permissive CORS headers, so "anonymous" is safe.

Verification

- Build (incl. DTS typecheck), unit tests, lint ✓
- Cypress e2e for crossOrigin and onLoad/onLoadFailed pass locally ✓

🤖 Generated with Claude Code
